### PR TITLE
Lookup improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
 - tip
 install:
 - go get -u -v github.com/fardog/secureoperator
+- go get -u -v github.com/fardog/secureoperator/cmd
 - go get -u -v github.com/fardog/secureoperator/cmd/secure-operator
 before_deploy: "make release"
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ release:
 	GOOS=windows GOARCH=386 go build -o release/secure-operator_windows-386.exe $(cmd_package)
 
 test:
-	go test -v ./
+	go test -v ./ ./cmd

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The `latest` tag will always be the build from the `master` branch. If you wish
 to use one of the stable releases, use its version tag when pulling, e.g.:
 
 ```
-docker pull fardog/secureoperator:v1.0.3
+docker pull fardog/secureoperator:v2.0.0
 ```
 
 ## Version Compatibility
@@ -50,7 +50,7 @@ always considered stable, but may break API compatibility. If you require API
 stability, either use the tagged releases or mirror on gopkg.in:
 
 ```
-go get -u gopkg.in/fardog/secureoperator.v1
+go get -u gopkg.in/fardog/secureoperator.v2
 ```
 
 ## Security
@@ -60,9 +60,17 @@ consider the following:
 
 * You must trust Google with your requests, see
   [their privacy statement][googlednspriv] for further details.
-* The initial lookup for the Google DNS endpoint happens over plain DNS using
-  your locally configured DNS resolver; there are plans to mitigate this in the
-  future, but at least _one_ DNS request will be sent unsecured.
+* The lookup for the Google DNS endpoint must happen in _some_ regard, although
+  how this is handled is up to you:
+    * The system DNS resolver is used to look up the endpoint (default)
+    * You provide a list of DNS servers to use for the endpoint lookup
+    * You provide the IP address(es) to the endpoint; and no unencrypted DNS
+      lookup will be performed. However if the addresses change while the
+      service is running, you will need to restart the service to provide new
+      addresses.
+      
+Information on the usage of these options is available with
+`secure-operator --help`. 
   
 ## Caveats/TODO
 
@@ -70,7 +78,8 @@ consider the following:
 * More thorough tests should be written
 * No caching is implemented, and probably never will. If you need caching, put
   your `secure-operator` server behind another DNS server which provides
-  caching.
+  caching. (TODO: write instructions on setup, or provide a docker-compose
+  configuration.)
 
 ## Acknowledgments
 

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -51,7 +51,8 @@ var (
 		"dns-servers",
 		"",
 		`DNS Servers used to look up the endpoint; system default is used if absent.
-        Ignored if "endpoint-ips" is set. Comma separated, e.g. "8.8.8.8,8.8.4.4".`,
+        Ignored if "endpoint-ips" is set. Comma separated, e.g. "8.8.8.8,8.8.4.4:53".
+        The port section is optional, and 53 will be used by default.`,
 	)
 
 	enableTCP = flag.Bool("tcp", true, "Listen on TCP")
@@ -99,17 +100,16 @@ func main() {
 	if err != nil {
 		log.Fatalf("error parsing endpoint-ips: %v", err)
 	}
-	dips, err := cmd.CSVtoIPs(*dnsServers)
+	dips, err := cmd.CSVtoEndpoints(*dnsServers)
 	if err != nil {
 		log.Fatalf("error parsing dns-servers: %v", err)
 	}
 
-	provider := secop.GDNSProvider{
-		Endpoint:    *endpoint,
+	provider := secop.NewGDNSProvider(*endpoint, &secop.GDNSOptions{
 		Pad:         *pad,
 		EndpointIPs: eips,
 		DNSServers:  dips,
-	}
+	})
 	options := &secop.HandlerOptions{}
 	handler := secop.NewHandler(provider, options)
 

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/miekg/dns"
 
 	secop "github.com/fardog/secureoperator"
+	"github.com/fardog/secureoperator/cmd"
 )
 
 var (
@@ -17,11 +20,6 @@ var (
 		"listen", ":53", "listen address, as `[host]:port`",
 	)
 
-	endpoint = flag.String(
-		"endpoint",
-		"https://dns.google.com/resolve",
-		"Google DNS-over-HTTPS endpoint url",
-	)
 	pad = flag.Bool(
 		"pad",
 		true,
@@ -32,6 +30,28 @@ var (
 		"level",
 		"info",
 		"Log level, one of: debug, info, warn, error, fatal, panic",
+	)
+
+	// resolution of the Google DNS endpoint; the interaction of these values is
+	// somewhat complex, and is further explained in the help message.
+	endpoint = flag.String(
+		"endpoint",
+		"https://dns.google.com/resolve",
+		"Google DNS-over-HTTPS endpoint url",
+	)
+	endpointIPs = flag.String(
+		"endpoint-ips",
+		"",
+		`IPs of the Google DNS-over-HTTPS endpoint; if provided, endpoint lookup is
+        skipped, and the host value in "endpoint" is sent as the Host header. Comma
+        separated with no spaces; e.g. "74.125.28.139,74.125.28.102". One server is
+        randomly chosen for each request, failed requests are not retried.`,
+	)
+	dnsServers = flag.String(
+		"dns-servers",
+		"",
+		`DNS Servers used to look up the endpoint; system default is used if absent.
+        Ignored if "endpoint-ips" is set. Comma separated, e.g. "8.8.8.8,8.8.4.4".`,
 	)
 
 	enableTCP = flag.Bool("tcp", true, "Listen on TCP")
@@ -61,6 +81,9 @@ func serve(net string) {
 
 func main() {
 	flag.Usage = func() {
+		_, exe := filepath.Split(os.Args[0])
+		fmt.Fprint(os.Stderr, "A DNS-protocol proxy for Google's DNS-over-HTTPS service.\n\n")
+		fmt.Fprintf(os.Stderr, "Usage:\n\n  %s [options]\n\nOptions:\n\n", exe)
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -69,13 +92,23 @@ func main() {
 	level, err := log.ParseLevel(*logLevel)
 	if err != nil {
 		log.Fatalf("invalid log level: %s", err.Error())
-		return
 	}
 	log.SetLevel(level)
 
+	eips, err := cmd.CSVtoIPs(*endpointIPs)
+	if err != nil {
+		log.Fatalf("error parsing endpoint-ips: %v", err)
+	}
+	dips, err := cmd.CSVtoIPs(*dnsServers)
+	if err != nil {
+		log.Fatalf("error parsing dns-servers: %v", err)
+	}
+
 	provider := secop.GDNSProvider{
-		Endpoint: *endpoint,
-		Pad:      *pad,
+		Endpoint:    *endpoint,
+		Pad:         *pad,
+		EndpointIPs: eips,
+		DNSServers:  dips,
 	}
 	options := &secop.HandlerOptions{}
 	handler := secop.NewHandler(provider, options)

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -20,10 +20,10 @@ var (
 		"listen", ":53", "listen address, as `[host]:port`",
 	)
 
-	pad = flag.Bool(
-		"pad",
-		true,
-		"Pad Google DNS-over-HTTPS requests to identical length",
+	noPad = flag.Bool(
+		"no-pad",
+		false,
+		"Disable padding of Google DNS-over-HTTPS requests to identical length",
 	)
 
 	logLevel = flag.String(
@@ -106,7 +106,7 @@ func main() {
 	}
 
 	provider, err := secop.NewGDNSProvider(*endpoint, &secop.GDNSOptions{
-		Pad:         *pad,
+		Pad:         !*noPad,
 		EndpointIPs: eips,
 		DNSServers:  dips,
 	})

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -105,11 +105,14 @@ func main() {
 		log.Fatalf("error parsing dns-servers: %v", err)
 	}
 
-	provider := secop.NewGDNSProvider(*endpoint, &secop.GDNSOptions{
+	provider, err := secop.NewGDNSProvider(*endpoint, &secop.GDNSOptions{
 		Pad:         *pad,
 		EndpointIPs: eips,
 		DNSServers:  dips,
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 	options := &secop.HandlerOptions{}
 	handler := secop.NewHandler(provider, options)
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// CSVtoIPs takes a comma-separated string of IPs, and parses to a []net.IP
+func CSVtoIPs(csv string) (ips []net.IP, err error) {
+	rs := strings.Split(csv, ",")
+
+	for _, r := range rs {
+		if r == "" {
+			continue
+		}
+
+		ip := net.ParseIP(r)
+		if ip == nil {
+			return ips, fmt.Errorf("unable to parse IP from string %s", r)
+		}
+		ips = append(ips, ip)
+	}
+
+	return
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -4,7 +4,29 @@ import (
 	"fmt"
 	"net"
 	"strings"
+
+	secop "github.com/fardog/secureoperator"
 )
+
+// CSVtoEndpoints takes a comma-separated string of endpoints, and parses to a
+// []secop.Endpoint
+func CSVtoEndpoints(csv string) (eps []secop.Endpoint, err error) {
+	reps := strings.Split(csv, ",")
+	for _, r := range reps {
+		if r == "" {
+			continue
+		}
+
+		ep, err := secop.ParseEndpoint(r, 53)
+		if err != nil {
+			return eps, err
+		}
+
+		eps = append(eps, ep)
+	}
+
+	return eps, err
+}
 
 // CSVtoIPs takes a comma-separated string of IPs, and parses to a []net.IP
 func CSVtoIPs(csv string) (ips []net.IP, err error) {

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import "testing"
+
+func TestCSVtoEndpoints(t *testing.T) {
+	type Case struct {
+		csv      string
+		err      bool
+		expected []string
+	}
+
+	cs := []Case{
+		Case{
+			"8.8.8.8:53,8.8.4.4:8053",
+			false,
+			[]string{"8.8.8.8:53", "8.8.4.4:8053"},
+		},
+		Case{
+			"8.8.8.8,8.8.4.4:8053",
+			false,
+			[]string{"8.8.8.8:53", "8.8.4.4:8053"},
+		},
+		Case{
+			"8.8.8.8",
+			false,
+			[]string{"8.8.8.8:53"},
+		},
+		Case{
+			"",
+			false,
+			[]string{},
+		},
+		Case{
+			"8.8.8.8:53:54",
+			true,
+			[]string{},
+		},
+	}
+
+	for i, c := range cs {
+		results, err := CSVtoEndpoints(c.csv)
+		if c.err && err == nil {
+			t.Errorf("%v: expected err, got none", i)
+		} else if !c.err && err != nil {
+			t.Errorf("%v: did not expect error, got: %v", i, err)
+		}
+
+		if e, r := len(c.expected), len(results); e != r {
+			t.Errorf("%v: expected %v results, got %v", i, e, r)
+			continue
+		}
+
+		for j, r := range results {
+			if r.String() != c.expected[j] {
+				t.Errorf("%v,%v: expected %v, got %v", i, j, r, c.expected[j])
+			}
+		}
+	}
+}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -57,3 +57,59 @@ func TestCSVtoEndpoints(t *testing.T) {
 		}
 	}
 }
+
+func TestCSVtoIPs(t *testing.T) {
+	type Case struct {
+		csv      string
+		err      bool
+		expected []string
+	}
+
+	cs := []Case{
+		Case{
+			"8.8.8.8,8.8.4.4",
+			false,
+			[]string{"8.8.8.8", "8.8.4.4"},
+		},
+		Case{
+			"8.8.8.8,8.8.4.4",
+			false,
+			[]string{"8.8.8.8", "8.8.4.4"},
+		},
+		Case{
+			"8.8.8.8",
+			false,
+			[]string{"8.8.8.8"},
+		},
+		Case{
+			"",
+			false,
+			[]string{},
+		},
+		Case{
+			"8.8.8.8:53",
+			true,
+			[]string{},
+		},
+	}
+
+	for i, c := range cs {
+		results, err := CSVtoIPs(c.csv)
+		if c.err && err == nil {
+			t.Errorf("%v: expected err, got none", i)
+		} else if !c.err && err != nil {
+			t.Errorf("%v: did not expect error, got: %v", i, err)
+		}
+
+		if e, r := len(c.expected), len(results); e != r {
+			t.Errorf("%v: expected %v results, got %v", i, e, r)
+			continue
+		}
+
+		for j, r := range results {
+			if r.String() != c.expected[j] {
+				t.Errorf("%v,%v: expected %v, got %v", i, j, r, c.expected[j])
+			}
+		}
+	}
+}

--- a/dns_client.go
+++ b/dns_client.go
@@ -14,6 +14,11 @@ import (
 	"github.com/miekg/dns"
 )
 
+var (
+	ErrInvalidEndpointString = errors.New("invalid endpoint string")
+	ErrFailedParsingIP       = errors.New("unable to parse IP from string")
+)
+
 // ParseEndpoint parses a string into an Endpoint object, where the endpoint
 // string is in the format of "ip:port". If a port is not present in the string,
 // the defaultPort is used.
@@ -21,12 +26,12 @@ func ParseEndpoint(endpoint string, defaultPort uint16) (ep Endpoint, err error)
 	e := strings.Split(endpoint, ":")
 
 	if len(e) > 2 {
-		return ep, errors.New("invalid format")
+		return ep, ErrInvalidEndpointString
 	}
 
 	ip := net.ParseIP(e[0])
 	if ip == nil {
-		return ep, fmt.Errorf("unable to parse IP from string %s", e[0])
+		return ep, ErrFailedParsingIP
 	}
 
 	ep.IP = ip

--- a/dns_client.go
+++ b/dns_client.go
@@ -49,7 +49,7 @@ type Endpoint struct {
 }
 
 func (e Endpoint) String() string {
-	return net.JoinHostPort(e.IP.String(), string(e.Port))
+	return net.JoinHostPort(e.IP.String(), fmt.Sprintf("%v", e.Port))
 }
 
 // Endpoints is a list of Endpoint objects
@@ -132,5 +132,5 @@ func (c *SimpleDNSClient) LookupIP(host string) ([]net.IP, error) {
 	// cache the record
 	c.cache[host] = rec
 
-	return entry.ips, nil
+	return rec.ips, nil
 }

--- a/dns_client.go
+++ b/dns_client.go
@@ -1,0 +1,136 @@
+package secureoperator
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// ParseEndpoint parses a string into an Endpoint object, where the endpoint
+// string is in the format of "ip:port". If a port is not present in the string,
+// the defaultPort is used.
+func ParseEndpoint(endpoint string, defaultPort uint16) (ep Endpoint, err error) {
+	e := strings.Split(endpoint, ":")
+
+	if len(e) > 2 {
+		return ep, errors.New("invalid format")
+	}
+
+	ip := net.ParseIP(e[0])
+	if ip == nil {
+		return ep, fmt.Errorf("unable to parse IP from string %s", e[0])
+	}
+
+	ep.IP = ip
+	ep.Port = defaultPort
+
+	if len(e) > 1 {
+		i, err := strconv.ParseUint(e[1], 10, 16)
+		if err != nil {
+			return ep, err
+		}
+
+		ep.Port = uint16(i)
+	}
+
+	return ep, err
+}
+
+// Endpoint represents a host/port combo
+type Endpoint struct {
+	IP   net.IP
+	Port uint16
+}
+
+func (e Endpoint) String() string {
+	return net.JoinHostPort(e.IP.String(), string(e.Port))
+}
+
+// Endpoints is a list of Endpoint objects
+type Endpoints []Endpoint
+
+// Random retrieves a random Endpoint from a list of Endpoints
+func (e Endpoints) Random() Endpoint {
+	return e[rand.Intn(len(e))]
+}
+
+type dnsCacheRecord struct {
+	msg     *dns.Msg
+	ips     []net.IP
+	expires time.Time
+}
+
+type dnsCache map[string]dnsCacheRecord
+
+// NewSimpleDNSClient creates a SimpleDNSClient
+func NewSimpleDNSClient(servers Endpoints) (*SimpleDNSClient, error) {
+	if len(servers) < 1 {
+		return nil, fmt.Errorf("at least one endpoint server is required")
+	}
+	return &SimpleDNSClient{
+		servers: servers,
+		cache:   dnsCache{},
+	}, nil
+}
+
+// SimpleDNSClient is a DNS client, primarily for internal use in secure
+// operator.
+//
+// It provides an in-memory cache, but was optimized to look up one address
+// at a time only.
+type SimpleDNSClient struct {
+	servers Endpoints
+	cache   dnsCache
+}
+
+// LookupIP looks up a single IP against the client's configured DNS servers,
+// returning a value from cache if its still valid.
+func (c *SimpleDNSClient) LookupIP(host string) ([]net.IP, error) {
+	// see if cache has the entry; if it's still good, return it
+	entry, ok := c.cache[host]
+	if ok && entry.expires.After(time.Now()) {
+		return entry.ips, nil
+	}
+
+	// we need to look it up
+	server := c.servers.Random()
+	msg := dns.Msg{}
+	msg.SetQuestion(dns.Fqdn(host), dns.TypeA)
+
+	r, err := dns.Exchange(&msg, server.String())
+	if err != nil {
+		return []net.IP{}, err
+	}
+
+	rec := dnsCacheRecord{
+		msg: r,
+	}
+
+	var shortestTTL uint32
+
+	for _, ans := range r.Answer {
+		h := ans.Header()
+
+		if shortestTTL == 0 || h.Ttl < shortestTTL {
+			shortestTTL = h.Ttl
+		}
+
+		if t, ok := ans.(*dns.A); ok {
+			rec.ips = append(rec.ips, t.A)
+		}
+	}
+
+	// set the expiry
+	rec.expires = time.Now().Add(time.Second * time.Duration(shortestTTL))
+
+	// cache the record
+	c.cache[host] = rec
+
+	return entry.ips, nil
+}

--- a/dns_client.go
+++ b/dns_client.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/miekg/dns"
 )
 
@@ -95,6 +96,7 @@ func (c *SimpleDNSClient) LookupIP(host string) ([]net.IP, error) {
 	// see if cache has the entry; if it's still good, return it
 	entry, ok := c.cache[host]
 	if ok && entry.expires.After(time.Now()) {
+		log.Debugf("simple dns cache hit for %v\n", host)
 		return entry.ips, nil
 	}
 
@@ -103,6 +105,7 @@ func (c *SimpleDNSClient) LookupIP(host string) ([]net.IP, error) {
 	msg := dns.Msg{}
 	msg.SetQuestion(dns.Fqdn(host), dns.TypeA)
 
+	log.Infof("simple dns lookup %v\n")
 	r, err := dns.Exchange(&msg, server.String())
 	if err != nil {
 		return []net.IP{}, err

--- a/dns_client_test.go
+++ b/dns_client_test.go
@@ -1,0 +1,45 @@
+package secureoperator
+
+import "testing"
+
+func TestParseEndpoint(t *testing.T) {
+	type Case struct {
+		c    string
+		p    uint16
+		ip   string
+		port uint16
+	}
+
+	cases := []Case{
+		Case{"8.8.8.8", 53, "8.8.8.8", 53},
+		Case{"8.8.4.4", 54, "8.8.4.4", 54},
+		Case{"8.8.8.8:8053", 53, "8.8.8.8", 8053},
+		Case{"8.8.4.4:8053", 53, "8.8.4.4", 8053},
+	}
+
+	for i, c := range cases {
+		e, err := ParseEndpoint(c.c, c.p)
+		if err != nil {
+			t.Fatalf("%v: %v", i, err)
+		}
+
+		if e.IP.String() != c.ip {
+			t.Errorf("%v: expected %v, got %v", i, e.IP, c.ip)
+		}
+		if e.Port != c.port {
+			t.Errorf("%v: expected %v, got %v", i, e.Port, c.port)
+		}
+	}
+}
+
+func TestParseEndpointErrors(t *testing.T) {
+	_, err := ParseEndpoint("8.8.8.8:53:54", 53)
+	if err != ErrInvalidEndpointString {
+		t.Fatal("expected ErrInvalidEndpointString")
+	}
+
+	_, err = ParseEndpoint("abc:53", 53)
+	if err != ErrFailedParsingIP {
+		t.Fatal("expected ErrFailedParsingIP")
+	}
+}

--- a/dns_client_test.go
+++ b/dns_client_test.go
@@ -1,6 +1,10 @@
 package secureoperator
 
-import "testing"
+import (
+	"net"
+	"testing"
+	"time"
+)
 
 func TestParseEndpoint(t *testing.T) {
 	type Case struct {
@@ -41,5 +45,57 @@ func TestParseEndpointErrors(t *testing.T) {
 	_, err = ParseEndpoint("abc:53", 53)
 	if err != ErrFailedParsingIP {
 		t.Fatal("expected ErrFailedParsingIP")
+	}
+}
+
+func TestDNSCache(t *testing.T) {
+	d := newDNSCache()
+
+	_, ok := d.Get("wut")
+	if ok {
+		t.Error("expected to retrieve no record, but got one")
+	}
+
+	d.Set("wut", dnsCacheRecord{
+		msg:     nil,
+		ips:     []net.IP{net.ParseIP("8.8.8.8")},
+		expires: time.Now().Add(time.Minute * 5),
+	})
+
+	r, ok := d.Get("wut")
+	if !ok {
+		t.Fatal("expected to retrieve a record, but did not get one")
+	}
+
+	if len(r.ips) != 1 {
+		t.Fatalf("expected one IP, but got none")
+	}
+
+	if r.ips[0].String() != "8.8.8.8" {
+		t.Errorf("got unexpected IP: %v", r.ips[0].String())
+	}
+
+	d.Set("cool", dnsCacheRecord{
+		msg:     nil,
+		ips:     []net.IP{net.ParseIP("8.8.4.4")},
+		expires: time.Now().Add(time.Minute * 5),
+	})
+
+	r, ok = d.Get("cool")
+	if !ok {
+		t.Fatal("expected to retrieve a record, but did not get one")
+	}
+
+	if len(r.ips) != 1 {
+		t.Fatalf("expected one IP, but got none")
+	}
+
+	if r.ips[0].String() != "8.8.4.4" {
+		t.Errorf("got unexpected IP: %v", r.ips[0].String())
+	}
+
+	r, ok = d.Get("nope")
+	if ok {
+		t.Error("expected to retrieve no record, but got one")
 	}
 }

--- a/provider.go
+++ b/provider.go
@@ -72,29 +72,6 @@ func (r DNSRR) RR() dns.RR {
 
 			v.Preference = uint16(pref)
 			v.Mx = c[1]
-		case *dns.SOA:
-			c := strings.Split(r.Data, " ")
-			if len(c) != 7 {
-				break
-			}
-
-			var errs []error
-			parseUint32 := func(s string) uint32 {
-				u, err := strconv.ParseUint(s, 10, 32)
-				if err != nil {
-					errs = append(errs, err)
-				}
-
-				return uint32(u)
-			}
-
-			v.Ns = c[0]
-			v.Mbox = c[1]
-			v.Serial = parseUint32(c[2])
-			v.Refresh = parseUint32(c[3])
-			v.Retry = parseUint32(c[4])
-			v.Expire = parseUint32(c[5])
-			v.Minttl = parseUint32(c[6])
 		}
 	} else {
 		rr = dns.RR(&dns.RFC3597{

--- a/provider.go
+++ b/provider.go
@@ -51,7 +51,7 @@ func (r DNSRR) RR() dns.RR {
 		Rdlength: uint16(len(r.Data)),
 	}
 
-	constructor, ok := dns.TypeToRR[uint16(r.Type)]
+	constructor, ok := dns.TypeToRR[r.Type]
 	if ok {
 		// Construct a new RR
 		rr = constructor()
@@ -72,6 +72,29 @@ func (r DNSRR) RR() dns.RR {
 
 			v.Preference = uint16(pref)
 			v.Mx = c[1]
+		case *dns.SOA:
+			c := strings.Split(r.Data, " ")
+			if len(c) != 7 {
+				break
+			}
+
+			var errs []error
+			parseUint32 := func(s string) uint32 {
+				u, err := strconv.ParseUint(s, 10, 32)
+				if err != nil {
+					errs = append(errs, err)
+				}
+
+				return uint32(u)
+			}
+
+			v.Ns = c[0]
+			v.Mbox = c[1]
+			v.Serial = parseUint32(c[2])
+			v.Refresh = parseUint32(c[3])
+			v.Retry = parseUint32(c[4])
+			v.Expire = parseUint32(c[5])
+			v.Minttl = parseUint32(c[6])
 		}
 	} else {
 		rr = dns.RR(&dns.RFC3597{

--- a/provider.go
+++ b/provider.go
@@ -45,9 +45,9 @@ func (r DNSRR) RR() dns.RR {
 	// Build an RR header
 	rrhdr := dns.RR_Header{
 		Name:     r.Name,
-		Rrtype:   uint16(r.Type),
+		Rrtype:   r.Type,
 		Class:    dns.ClassINET,
-		Ttl:      uint32(r.TTL),
+		Ttl:      r.TTL,
 		Rdlength: uint16(len(r.Data)),
 	}
 

--- a/provider_google.go
+++ b/provider_google.go
@@ -3,6 +3,7 @@ package secureoperator
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 )
 
@@ -86,8 +87,10 @@ type GDNSResponse struct {
 // GDNSProvider is the Google DNS-over-HTTPS provider; it implements the
 // Provider interface.
 type GDNSProvider struct {
-	Endpoint string
-	Pad      bool
+	Endpoint    string
+	Pad         bool
+	EndpointIPs []net.IP
+	DNSServers  []net.IP
 }
 
 // Query sends a DNS question to Google, and returns the response

--- a/provider_google_test.go
+++ b/provider_google_test.go
@@ -30,9 +30,9 @@ func TestQuery(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	g := GDNSProvider{
-		Endpoint: ts.URL,
-		Pad:      false,
+	g, err := NewGDNSProvider(ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	resp, err := g.Query(DNSQuestion{
@@ -82,9 +82,9 @@ func TestPadding(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	g := GDNSProvider{
-		Endpoint: ts.URL,
-		Pad:      true,
+	g, err := NewGDNSProvider(ts.URL, &GDNSOptions{Pad: true})
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	questions := []DNSQuestion{
@@ -117,9 +117,9 @@ func TestNameTooLong(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	g := GDNSProvider{
-		Endpoint: ts.URL,
-		Pad:      true,
+	g, err := NewGDNSProvider(ts.URL, &GDNSOptions{Pad: true})
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// a name longer that 253 bytes should be an error


### PR DESCRIPTION
_**Note:** this is a work in progress. I need to test it more thoroughly in my environment before it is merged/released._

Adds a few features to `secure-operator` that will make it more pleasant to run in most environments:
* No longer dependent on the system DNS resolver to locate Google's DNS-over-HTTPS service; it can either:
    * Perform its own DNS lookups to a user-supplied list of DNS servers, or
    * Avoid DNS lookups entirely by using a user-supplied list of IP addresses for the DNS-over-HTTPS service
* Improved usage messages from `secure-operator --help`

This feature requires API changes to the `GDNSProvider` struct, so this will be released as `v2.0.0`; however if you are using this library to build your own DNS servers, there should be no meaningful changes.