### PR TITLE
replace DNSRR.RR with DNSRR.DNSRR; deprecate moved method

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -80,7 +80,7 @@ func transformRR(rrs []DNSRR, logType string) []dns.RR {
 	var t []dns.RR
 
 	for _, r := range rrs {
-		if rr, err := r.DNSRR(); err != nil {
+		if rr, err := r.RR(); err != nil {
 			log.Errorln("unable to translate record rr", logType, r, err)
 		} else {
 			t = append(t, rr)

--- a/provider.go
+++ b/provider.go
@@ -18,20 +18,16 @@ type DNSRR struct {
 	Data string `json:"data,omitempty"`
 }
 
-// RR is deprecated as of 2.2.0, use DNSRR instead
-func (r DNSRR) RR() dns.RR {
-	hdr := dns.RR_Header{Name: r.Name, Rrtype: r.Type, Class: dns.ClassINET, Ttl: r.TTL}
-	str := hdr.String() + r.Data
-	rr, _ := dns.NewRR(str)
-	return rr
-}
-
-// DNSRR transforms a DNSRR to a dns.RR; returns `nil` if an RR could not be
-// created from the record.
-func (r DNSRR) DNSRR() (dns.RR, error) {
+// RR transforms a DNSRR to a dns.RR
+func (r DNSRR) RR() (dns.RR, error) {
 	hdr := dns.RR_Header{Name: r.Name, Rrtype: r.Type, Class: dns.ClassINET, Ttl: r.TTL}
 	str := hdr.String() + r.Data
 	return dns.NewRR(str)
+}
+
+// DNSRR is deprecated as of 3.0.0; use RR instead.
+func (r DNSRR) DNSRR() (dns.RR, error) {
+	return r.RR()
 }
 
 func (r DNSRR) String() string {

--- a/provider_test.go
+++ b/provider_test.go
@@ -17,7 +17,7 @@ func TestDNSRRTypeA(t *testing.T) {
 		Data: "10.10.10.1",
 	}
 
-	rr, err := r.DNSRR()
+	rr, err := r.RR()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestDNSRRTypeMX(t *testing.T) {
 		Data: "10 mail.who.wut.co.jp",
 	}
 
-	rr, err := r.DNSRR()
+	rr, err := r.RR()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestDNSRRTypeCNAME(t *testing.T) {
 		Data: "omg.wtf.bbq",
 	}
 
-	rr, err := r.DNSRR()
+	rr, err := r.RR()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +116,7 @@ func TestDNSRRTypeAAAA(t *testing.T) {
 		Data: "::1",
 	}
 
-	rr, err := r.DNSRR()
+	rr, err := r.RR()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
completes a deprecation of the `DNSRR.RR()` method, which never returned an error but really should have. replacing it is a method of the same name, but with an updated signature.