### PR TITLE
Support optionally enabling EDNS

### DIFF
--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -55,6 +56,24 @@ var (
 		`DNS Servers used to look up the endpoint; system default is used if absent.
         Ignored if "endpoint-ips" is set. Comma separated, e.g. "8.8.8.8,8.8.4.4:53".
         The port section is optional, and 53 will be used by default.`,
+	)
+	autoEDNS = flag.Bool(
+		"auto-edns-subnet",
+		false,
+		`By default, we use an EDNS subnet of 0.0.0.0/0 which does not reveal your
+        IP address or subnet to authoratative DNS servers. If privacy of your IP
+        address is not a concern and you want to take advantage of an authoratative
+        server determining the best DNS results for you, set this flag. This flag
+        specifies that Google should choose what subnet to send; if you'd like to
+        specify your own subnet, use the -edns-subnet option.`,
+	)
+	ednsSubnet = flag.String(
+		"edns-subnet",
+		"0.0.0.0/0",
+		`Specify a subnet to be sent in the edns0-client-subnet option; by default
+        we specify that this option should not be used, for privacy. If
+        -auto-edns-subnet is used, the value specified here is ignored.
+       `,
 	)
 
 	enableTCP = flag.Bool("tcp", true, "Listen on TCP")
@@ -111,10 +130,22 @@ func main() {
 		log.Fatalf("error parsing dns-servers: %v", err)
 	}
 
+	edns := *ednsSubnet
+	if *autoEDNS {
+		edns = ""
+	}
+	if _, _, err := net.ParseCIDR(edns); edns != "" && err != nil {
+		log.Fatal(err)
+	}
+	if edns != "0.0.0.0/0" {
+		log.Warn("EDNS will be used; authoritative name servers may be able to determine your location")
+	}
+
 	provider, err := secop.NewGDNSProvider(*endpoint, &secop.GDNSOptions{
 		Pad:         !*noPad,
 		EndpointIPs: eips,
 		DNSServers:  dips,
+		EDNSSubnet:  edns,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -69,7 +69,7 @@ var (
 	)
 	ednsSubnet = flag.String(
 		"edns-subnet",
-		"0.0.0.0/0",
+		secop.GoogleEDNSSentinelValue,
 		`Specify a subnet to be sent in the edns0-client-subnet option; by default
         we specify that this option should not be used, for privacy. If
         -auto-edns-subnet is used, the value specified here is ignored.
@@ -137,7 +137,7 @@ func main() {
 	if _, _, err := net.ParseCIDR(edns); edns != "" && err != nil {
 		log.Fatal(err)
 	}
-	if edns != "0.0.0.0/0" {
+	if edns != secop.GoogleEDNSSentinelValue {
 		log.Warn("EDNS will be used; authoritative name servers may be able to determine your location")
 	}
 

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -142,10 +142,11 @@ func main() {
 	}
 
 	provider, err := secop.NewGDNSProvider(*endpoint, &secop.GDNSOptions{
-		Pad:         !*noPad,
-		EndpointIPs: eips,
-		DNSServers:  dips,
-		EDNSSubnet:  edns,
+		Pad:                 !*noPad,
+		EndpointIPs:         eips,
+		DNSServers:          dips,
+		UseEDNSsubnetOption: true,
+		EDNSSubnet:          edns,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/provider_google.go
+++ b/provider_google.go
@@ -99,6 +99,10 @@ type GDNSOptions struct {
 	// DNSServers is a list of Endpoints to be used as DNS servers when looking
 	// up the endpoint; if not provided, the system DNS resolver is used.
 	DNSServers Endpoints
+	// The EDNS subnet to send in the edns0-client-subnet option. If not
+	// specified, Google determines this automatically. To specify that the
+	// option should not be set, use the value "0.0.0.0/0".
+	EDNSSubnet string
 }
 
 // NewGDNSProvider creates a GDNSProvider
@@ -197,7 +201,10 @@ func (g GDNSProvider) newRequest(q DNSQuestion) (*http.Request, error) {
 
 	qry.Add("name", q.Name)
 	qry.Add("type", dnsType)
-	qry.Add("edns_client_subnet", "0.0.0.0/0")
+
+	if g.opts.EDNSSubnet != "" {
+		qry.Add("edns_client_subnet", g.opts.EDNSSubnet)
+	}
 
 	httpreq.URL.RawQuery = qry.Encode()
 

--- a/provider_google.go
+++ b/provider_google.go
@@ -14,6 +14,9 @@ import (
 const (
 	// DNSNameMaxBytes is the maximum number of bytes a DNS name may contain
 	DNSNameMaxBytes = 253
+	// GoogleEDNSSentinelValue is the value that when sent to Google as the
+	// EDNS value, means "do not use EDNS".
+	GoogleEDNSSentinelValue = "0.0.0.0/0"
 	// max number of characters in a 16-bit uint integer, converted to string
 	extraPad         = 5
 	paddingParameter = "random_padding"
@@ -99,6 +102,18 @@ type GDNSOptions struct {
 	// DNSServers is a list of Endpoints to be used as DNS servers when looking
 	// up the endpoint; if not provided, the system DNS resolver is used.
 	DNSServers Endpoints
+	// UseEDNSSubnetOption is a temporary option which must be specified to
+	// enable an EDNS value other than the default of "0.0.0.0/0", which is
+	// Google's sentinel value for "do not send EDNS with this request".
+	//
+	// When this option is false, the value in EDNSSubnet is ignored.
+	//
+	// This temporary option exists becase the API change may have been
+	// dangerous to consumers of this library: to send EDNS by default.
+	//
+	// Deprecated: this option will be removed in v4, and the default behavior
+	// will be that Google decides EDNS behavior.
+	UseEDNSsubnetOption bool
 	// The EDNS subnet to send in the edns0-client-subnet option. If not
 	// specified, Google determines this automatically. To specify that the
 	// option should not be set, use the value "0.0.0.0/0".
@@ -202,8 +217,12 @@ func (g GDNSProvider) newRequest(q DNSQuestion) (*http.Request, error) {
 	qry.Add("name", q.Name)
 	qry.Add("type", dnsType)
 
-	if g.opts.EDNSSubnet != "" {
-		qry.Add("edns_client_subnet", g.opts.EDNSSubnet)
+	edns := GoogleEDNSSentinelValue
+	if g.opts.UseEDNSsubnetOption {
+		edns = g.opts.EDNSSubnet
+	}
+	if edns != "" {
+		qry.Add("edns_client_subnet", edns)
 	}
 
 	httpreq.URL.RawQuery = qry.Encode()

--- a/provider_google.go
+++ b/provider_google.go
@@ -102,13 +102,13 @@ type GDNSOptions struct {
 	// DNSServers is a list of Endpoints to be used as DNS servers when looking
 	// up the endpoint; if not provided, the system DNS resolver is used.
 	DNSServers Endpoints
-	// UseEDNSSubnetOption is a temporary option which must be specified to
-	// enable an EDNS value other than the default of "0.0.0.0/0", which is
-	// Google's sentinel value for "do not send EDNS with this request".
+	// UseEDNSSubnetOption is an option which must be specified to enable an
+	// EDNS value other than the default of "0.0.0.0/0", which is Google's
+	// sentinel value for "do not send EDNS with this request".
 	//
 	// When this option is false, the value in EDNSSubnet is ignored.
 	//
-	// This temporary option exists becase the API change may have been
+	// This temporary option exists because the API change may have been
 	// dangerous to consumers of this library: to send EDNS by default.
 	//
 	// Deprecated: this option will be removed in v4, and the default behavior

--- a/provider_google_test.go
+++ b/provider_google_test.go
@@ -103,6 +103,43 @@ func TestEDNS(t *testing.T) {
 	}
 }
 
+func TestEDNSOmittedWhenBlank(t *testing.T) {
+	name := "example.com"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if n := q.Get("name"); n != name {
+			t.Errorf("unexpected name in query: %v", n)
+		}
+		if tp := q.Get("type"); tp != strconv.Itoa(int(dns.TypeA)) {
+			t.Errorf("unexpected type in query: %v", tp)
+		}
+		if strings.Contains(r.URL.RawQuery, "edns_client_subnet") {
+			t.Errorf("edns_client_subnet should be omitted")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, gresp)
+	}))
+	defer ts.Close()
+
+	g, err := NewGDNSProvider(ts.URL, &GDNSOptions{
+		UseEDNSsubnetOption: true,
+		EDNSSubnet:          "",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = g.Query(DNSQuestion{
+		Name: name,
+		Type: dns.TypeA,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestEDNSIgnoredByDefault(t *testing.T) {
 	// Deprecated: remove test in v4
 	name := "example.com"


### PR DESCRIPTION
Google's [DNS-over-HTTPS Docs](https://developers.google.com/speed/public-dns/docs/dns-over-https) describe the `edns_client_subnet` option and how they use it. Previously, we've always set the value of that parameter to `0.0.0.0/0` which is the sentinel value Google uses to send no EDNS value to upstream authoratative name servers.

It's now possible to send EDNS values if you prefer them; this would allow authoratative DNS servers to choose results based on your location, at the expense of the servers having information about your location. To allow Google to choose the value sent, use the `-auto-edns-subnet` flag. If you wish to specify your own subnet, use the `-edns-subnet` flag followed by a valid CIDR, such as `-edns-subnet 64.10.0.0/20`.

The internal API for this is somewhat awkward, because I wanted to introduce the API slowly, so any consumers of this libary have time to notice and update. The new options are marked as deprecated, and will be removed in version 4 (this will be released as version 3).

Fixes #21 
  