### PR TITLE
support provider defaults for google, cloudflare

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-- 1.9
-- 1.10
+- "1.9"
+- "1.10"
 - tip
 install:
 - go get -u -v github.com/fardog/secureoperator

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-- 1.8
 - 1.9
+- 1.10
 - tip
 install:
 - go get -u -v github.com/fardog/secureoperator
@@ -24,4 +24,4 @@ deploy:
   on:
     repo: fardog/secureoperator
     tags: true
-    go: 1.9
+    go: 1.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY . /go/src/github.com/fardog/secureoperator
 WORKDIR /go/src/github.com/fardog/secureoperator/cmd/secure-operator
 RUN go install -v
 
-CMD secure-operator --listen 0.0.0.0:53
+ENTRYPOINT ["secure-operator", "--listen", "0.0.0.0:53"]

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ across the internet using HTTPS.
 It's known to work with the following providers:
 
 * [Google][dnsoverhttps] - Well tested and configured by default
-* **Alpha:** [Cloudflare][] - See [release notes](#cloudflare) for configuration
-  and caveats
+* [Cloudflare][] _(Beta)_ - May be used by passing the `--cloudflare` flag
 
 ## Installation
 
@@ -70,34 +69,6 @@ stability, either use the tagged releases or mirror on gopkg.in:
 go get -u gopkg.in/fardog/secureoperator.v3
 ```
 
-## Cloudflare
-
-[Cloudflare][] can be used as an DNS-over-HTTPS provider today, but requires
-some special configuration. Try the following:
-
-```
-$ secure-operator \
-  -endpoint https://cloudflare-dns.com/dns-query\?ct\=application/dns-json \
-  -endpoint-ips 1.1.1.1,1.0.0.1
-```
-
-Support for [Cloudflare][] as a DNS-over-HTTPS will be added as a CLI flag in
-the future, however the above will work with the current version of
-secureoperator.
-
-### Known Issues
-
-Cloudflare is not fully tested yet; it should work for common cases, however: 
-
-* Requests require a Content-Type parameter to be present in the URL, which must
-  be provided in the CLI.
-* EDNS is not supported; this is an intentional choice by Cloudflare, which
-  means any EDNS setting you provide when using Cloudflare as a provider will
-  be silently ignored.
-
-For a production environment, the Google provider (default) is your best option
-today. If you're brave, please test Cloudflare and [report any issues][issues]!
-
 ## Security
 
 Note that while DNS requests are made over HTTPS, this does not imply "secure";
@@ -130,6 +101,17 @@ following areas could use work:
 * Contributions to [reverseoperator][], the work-in-progress sibling project to
   secureoperator which enables API compatible independent DNS-over-HTTPS servers
   to be run
+
+### Known Issues
+
+Cloudflare is not fully tested yet; it should work for common cases, however: 
+
+* EDNS is not supported; this is an intentional choice by Cloudflare, which
+  means any EDNS setting you provide when using Cloudflare as a provider will
+  be silently ignored.
+
+For a production environment, the Google provider (default) is your best option
+today. If you're brave, please test Cloudflare and [report any issues][issues]!
 
 ## Acknowledgments
 

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -47,8 +47,8 @@ var (
 		false,
 		fmt.Sprintf(`Use Google defaults. When set, the following options will be used unless
 explicitly overridden:
-    dns-servers: 8.8.8.8,8.8.4.4
-    endpoint: %v`, gdnsEndpoint),
+	dns-servers: 8.8.8.8,8.8.4.4
+	endpoint: %v`, gdnsEndpoint),
 	)
 	cloudflare = flag.Bool(
 		"cloudflare",
@@ -57,7 +57,7 @@ explicitly overridden:
 unless explicitly overridden:
 	dns-servers: 1.1.1.1,1.0.0.1
 	params: ct=application/dns-json
-    endpoint: %v`, cloudflareEndpoint),
+	endpoint: %v`, cloudflareEndpoint),
 	)
 
 	// resolution of the Google DNS endpoint; the interaction of these values is

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -55,7 +55,7 @@ explicitly overridden:
 		false,
 		fmt.Sprintf(`Use Cloudflare defaults. When set, the following options will be used
 unless explicitly overridden:
-	dns-servers: 1.1.1.1,1.0.0.1
+	dns-servers: 1.0.0.1,1.1.1.1
 	params: ct=application/dns-json
 	endpoint: %v`, cloudflareEndpoint),
 	)
@@ -216,8 +216,8 @@ specify multiple as:
 		}
 		if len(opts.DNSServers) == 0 {
 			opts.DNSServers = []secop.Endpoint{
-				secop.Endpoint{IP: net.ParseIP("1.1.1.1"), Port: 53},
 				secop.Endpoint{IP: net.ParseIP("1.0.0.1"), Port: 53},
+				secop.Endpoint{IP: net.ParseIP("1.1.1.1"), Port: 53},
 			}
 		}
 		if _, ok := opts.QueryParameters["ct"]; !ok {

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -16,6 +17,11 @@ import (
 
 	secop "github.com/fardog/secureoperator"
 	"github.com/fardog/secureoperator/cmd"
+)
+
+const (
+	gdnsEndpoint       = "https://dns.google.com/resolve"
+	cloudflareEndpoint = "https://cloudflare-dns.com/dns-query"
 )
 
 var (
@@ -35,49 +41,72 @@ var (
 		"Log level, one of: debug, info, warn, error, fatal, panic",
 	)
 
+	// one-stop configuration flags; when used, these configure sane defaults
+	google = flag.Bool(
+		"google",
+		false,
+		fmt.Sprintf(`Use Google defaults. When set, the following options will be used unless
+explicitly overridden:
+    dns-servers: 8.8.8.8,8.8.4.4
+    endpoint: %v`, gdnsEndpoint),
+	)
+	cloudflare = flag.Bool(
+		"cloudflare",
+		false,
+		fmt.Sprintf(`Use Cloudflare defaults. When set, the following options will be used
+unless explicitly overridden:
+	dns-servers: 1.1.1.1,1.0.0.1
+	params: ct=application/dns-json
+    endpoint: %v`, cloudflareEndpoint),
+	)
+
 	// resolution of the Google DNS endpoint; the interaction of these values is
 	// somewhat complex, and is further explained in the help message.
 	endpoint = flag.String(
 		"endpoint",
-		"https://dns.google.com/resolve",
-		"Google DNS-over-HTTPS endpoint url",
+		gdnsEndpoint,
+		"DNS-over-HTTPS endpoint url",
 	)
 	endpointIPs = flag.String(
 		"endpoint-ips",
 		"",
-		`IPs of the Google DNS-over-HTTPS endpoint; if provided, endpoint lookup is
-        skipped, and the host value in "endpoint" is sent as the Host header. Comma
-        separated with no spaces; e.g. "74.125.28.139,74.125.28.102". One server is
-        randomly chosen for each request, failed requests are not retried.`,
+		`IPs of the DNS-over-HTTPS endpoint; if provided, endpoint lookup is
+skipped, and the host value in "endpoint" is sent as the Host header. Comma
+separated with no spaces; e.g. "74.125.28.139,74.125.28.102". One server is
+randomly chosen for each request, failed requests are not retried.`,
 	)
 	dnsServers = flag.String(
 		"dns-servers",
 		"",
 		`DNS Servers used to look up the endpoint; system default is used if absent.
-        Ignored if "endpoint-ips" is set. Comma separated, e.g. "8.8.8.8,8.8.4.4:53".
-        The port section is optional, and 53 will be used by default.`,
+Ignored if "endpoint-ips" is set. Comma separated, e.g. "8.8.8.8,8.8.4.4:53".
+The port section is optional, and 53 will be used by default.`,
 	)
 	autoEDNS = flag.Bool(
 		"auto-edns-subnet",
 		false,
 		`By default, we use an EDNS subnet of 0.0.0.0/0 which does not reveal your
-        IP address or subnet to authoratative DNS servers. If privacy of your IP
-        address is not a concern and you want to take advantage of an authoratative
-        server determining the best DNS results for you, set this flag. This flag
-        specifies that Google should choose what subnet to send; if you'd like to
-        specify your own subnet, use the -edns-subnet option.`,
+IP address or subnet to authoratative DNS servers. If privacy of your IP
+address is not a concern and you want to take advantage of an authoratative
+server determining the best DNS results for you, set this flag. This flag
+specifies that Google should choose what subnet to send; if you'd like to
+specify your own subnet, use the -edns-subnet option.`,
 	)
 	ednsSubnet = flag.String(
 		"edns-subnet",
 		secop.GoogleEDNSSentinelValue,
 		`Specify a subnet to be sent in the edns0-client-subnet option; by default
-        we specify that this option should not be used, for privacy. If
-        -auto-edns-subnet is used, the value specified here is ignored.
+we specify that this option should not be used, for privacy. If
+-auto-edns-subnet is used, the value specified here is ignored.
        `,
 	)
 
 	enableTCP = flag.Bool("tcp", true, "Listen on TCP")
 	enableUDP = flag.Bool("udp", true, "Listen on UDP")
+
+	// variables set in main body
+	headers         = make(cmd.KeyValue)
+	queryParameters = make(cmd.KeyValue)
 )
 
 func serve(net string) {
@@ -102,6 +131,21 @@ func serve(net string) {
 }
 
 func main() {
+	// non-standard flag vars
+	flag.Var(
+		headers,
+		"header",
+		`Additional headers to be sent with http requests, as Key=Value; specify
+multiple as:
+    -header Key-1=Value-1-1 -header Key-1=Value1-2 -header Key-2=Value-2`,
+	)
+	flag.Var(
+		queryParameters,
+		"param",
+		`Additional query parameters to be sent with http requests, as key=value;
+specify multiple as:
+    -param key1=value1-1 -param key1=value1-2 -param key2=value2`,
+	)
 	flag.Usage = func() {
 		_, exe := filepath.Split(os.Args[0])
 		fmt.Fprint(os.Stderr, "A DNS-protocol proxy for Google's DNS-over-HTTPS service.\n\n")
@@ -120,6 +164,10 @@ func main() {
 		log.Fatalf("invalid log level: %s", err.Error())
 	}
 	log.SetLevel(level)
+
+	if *google && *cloudflare {
+		log.Fatalf("you may not specify `-google` and `-cloudflare` arguments together")
+	}
 
 	eips, err := cmd.CSVtoIPs(*endpointIPs)
 	if err != nil {
@@ -141,13 +189,43 @@ func main() {
 		log.Warn("EDNS will be used; authoritative name servers may be able to determine your location")
 	}
 
-	provider, err := secop.NewGDNSProvider(*endpoint, &secop.GDNSOptions{
+	ep := *endpoint
+	opts := &secop.GDNSOptions{
 		Pad:                 !*noPad,
 		EndpointIPs:         eips,
 		DNSServers:          dips,
 		UseEDNSsubnetOption: true,
 		EDNSSubnet:          edns,
-	})
+		QueryParameters:     map[string][]string(queryParameters),
+		Headers:             http.Header(headers),
+	}
+
+	// handle "sane defaults" if requested; only where settings are not explicitly
+	// provided by the user
+	if *google {
+		if len(opts.DNSServers) == 0 {
+			opts.DNSServers = []secop.Endpoint{
+				secop.Endpoint{IP: net.ParseIP("8.8.8.8"), Port: 53},
+				secop.Endpoint{IP: net.ParseIP("8.8.4.4"), Port: 53},
+			}
+		}
+	} else if *cloudflare {
+		// override only if it's currently the default
+		if ep == gdnsEndpoint {
+			ep = cloudflareEndpoint
+		}
+		if len(opts.DNSServers) == 0 {
+			opts.DNSServers = []secop.Endpoint{
+				secop.Endpoint{IP: net.ParseIP("1.1.1.1"), Port: 53},
+				secop.Endpoint{IP: net.ParseIP("1.0.0.1"), Port: 53},
+			}
+		}
+		if _, ok := opts.QueryParameters["ct"]; !ok {
+			opts.QueryParameters["ct"] = []string{"application/dns-json"}
+		}
+	}
+
+	provider, err := secop.NewGDNSProvider(ep, opts)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -46,3 +46,32 @@ func CSVtoIPs(csv string) (ips []net.IP, err error) {
 
 	return
 }
+
+type KeyValue map[string][]string
+
+func (k KeyValue) Set(kv string) error {
+	kvs := strings.SplitN(kv, "=", 2)
+	if len(kvs) != 2 {
+		return fmt.Errorf("invalid format for %v; expected KEY=VALUE", kv)
+	}
+	key, value := kvs[0], kvs[1]
+
+	if vs, ok := k[key]; ok {
+		k[key] = append(vs, value)
+	} else {
+		k[key] = []string{value}
+	}
+
+	return nil
+}
+
+func (k KeyValue) String() string {
+	var s []string
+	for k, vs := range k {
+		for _, v := range vs {
+			s = append(s, fmt.Sprintf("%v=%v", k, v))
+		}
+	}
+
+	return strings.Join(s, " ")
+}

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -113,3 +113,38 @@ func TestCSVtoIPs(t *testing.T) {
 		}
 	}
 }
+
+func TestKeyValue(t *testing.T) {
+	kv := make(KeyValue)
+
+	kv.Set("key1=value=value")
+	kv.Set("key2=value2-1")
+	kv.Set("key2=value2-2")
+
+	if vs, ok := kv["key1"]; ok {
+		if len(vs) == 1 {
+			if vs[0] != "value=value" {
+				t.Errorf("unexpected value %v", vs[0])
+			}
+		} else {
+			t.Errorf("expected key1 value to be length 1, saw %v", vs)
+		}
+	} else {
+		t.Error("did not get value for key1")
+	}
+
+	if vs, ok := kv["key2"]; ok {
+		if len(vs) == 2 {
+			if vs[0] != "value2-1" {
+				t.Errorf("unexpected value %v", vs[0])
+			}
+			if vs[1] != "value2-2" {
+				t.Errorf("unexpected value %v", vs[1])
+			}
+		} else {
+			t.Errorf("unexpected length for %v", vs)
+		}
+	} else {
+		t.Error("did not get value for key2")
+	}
+}


### PR DESCRIPTION
* allows passing of simple `-google` or `-cloudflare` flags to
  configure google or cloudflare DNS, respectively. Provides sane
  defaults for each, and avoids some unintuitive settings needed
  for cloudflare to work properly.
* adds new CLI flags for specifying DNS headers or additional
  query parameters which should be sent along with the request to
  the DNS-over-HTTPS server
* fixes CLI flag "help" indentation for newer golang
* update CI and build versions
* use `ENTRYPOINT` in dockerfile for more pleasant container use