### PR TITLE
Add Quad9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It's known to work with the following providers:
 
 * [Google][dnsoverhttps] - Well tested and configured by default
 * [Cloudflare][] _(Beta)_ - May be used by passing the `--cloudflare` flag
-
+* [Quad9][] _(Beta)_ - May be used by passing the `--quad9' flag
 ## Installation
 
 You may retrieve binaries from [the releases page][releases], or install using

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -63,8 +63,8 @@ unless explicitly overridden:
 	quad9 = flag.Bool(
 		"quad9",
 		false,
-		fmt.Sprintf(`Use Quad9 defaults. Those will be used,
- unless explicitly overrriden:
+		fmt.Sprintf(`Use Quad9 defaults. When set, the following options will be used
+unless explicitly overriden:
 	dns-servers: 9.9.9.9, 149.112.112.112
 	params: ct=application/dns-json
 	endpoint : %v`, quad9Endpoint),

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -22,7 +22,7 @@ import (
 const (
 	gdnsEndpoint       = "https://dns.google.com/resolve"
 	cloudflareEndpoint = "https://cloudflare-dns.com/dns-query"
-	quad9Endpoint = "https://dns.quad9.net/dns-query"
+	quad9Endpoint      = "https://dns.quad9.net/dns-query"
 )
 
 var (
@@ -68,7 +68,7 @@ unless explicitly overriden:
 	dns-servers: 9.9.9.9, 149.112.112.112
 	params: ct=application/dns-json
 	endpoint : %v`, quad9Endpoint),
-        )
+	)
 	// resolution of the Google DNS endpoint; the interaction of these values is
 	// somewhat complex, and is further explained in the help message.
 	endpoint = flag.String(
@@ -175,7 +175,7 @@ specify multiple as:
 	log.SetLevel(level)
 
 	if *google && *cloudflare || *google && *quad9 ||
-	   *cloudflare && *quad9 || *google && *cloudflare && *quad9 {
+		*cloudflare && *quad9 || *google && *cloudflare && *quad9 {
 		log.Fatalf("you may not specify `-google` and `-cloudflare` and `-quad9` arguments together")
 	}
 
@@ -234,20 +234,20 @@ specify multiple as:
 			opts.QueryParameters["ct"] = []string{"application/dns-json"}
 		}
 	} else if *quad9 {
-                // override only if it's currently the default
-                if ep == gdnsEndpoint {
-                        ep = quad9Endpoint
-                }
-                if len(opts.DNSServers) == 0 {
-                        opts.DNSServers = []secop.Endpoint{
-                                secop.Endpoint{IP: net.ParseIP("9.9.9.9"), Port: 53},
-                                secop.Endpoint{IP: net.ParseIP("149.112.112.112"), Port: 53},
-                        }
-                }
-                if _, ok := opts.QueryParameters["ct"]; !ok {
-                        opts.QueryParameters["ct"] = []string{"application/dns-json"}
-                }
-        }
+		// override only if it's currently the default
+		if ep == gdnsEndpoint {
+			ep = quad9Endpoint
+		}
+		if len(opts.DNSServers) == 0 {
+			opts.DNSServers = []secop.Endpoint{
+				secop.Endpoint{IP: net.ParseIP("9.9.9.9"), Port: 53},
+				secop.Endpoint{IP: net.ParseIP("149.112.112.112"), Port: 53},
+			}
+		}
+		if _, ok := opts.QueryParameters["ct"]; !ok {
+			opts.QueryParameters["ct"] = []string{"application/dns-json"}
+		}
+	}
 
 	provider, err := secop.NewGDNSProvider(ep, opts)
 	if err != nil {

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -176,7 +176,7 @@ specify multiple as:
 
 	if *google && *cloudflare || *google && *quad9 ||
 	   *cloudflare && *quad9 || *google && *cloudflare && *quad9 {
-		log.Fatalf("you may not specify `-google` and `-cloudflare` and '-quad9` arguments together")
+		log.Fatalf("you may not specify `-google` and `-cloudflare` and `-quad9` arguments together")
 	}
 
 	eips, err := cmd.CSVtoIPs(*endpointIPs)


### PR DESCRIPTION
Quad9 now has DNS over HTTPS support.