### PR TITLE
Add options: -http2 -cacert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-package = github.com/fardog/secureoperator
-cmd_package = $(package)/cmd/secure-operator
+package = .
+cmd_package = ./cmd/secure-operator
 
 .PHONY: release test
 .DEFAULT_GOAL := test

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -43,12 +43,6 @@ var (
 		"Log level, one of: debug, info, warn, error, fatal, panic",
 	)
 
-	http2 = flag.Bool(
-		"http2",
-		false,
-		"Using http2 for query connection",
-	)
-
 	// one-stop configuration flags; when used, these configure sane defaults
 	google = flag.Bool(
 		"google",
@@ -123,6 +117,18 @@ we specify that this option should not be used, for privacy. If
 	// variables set in main body
 	headers         = make(cmd.KeyValue)
 	queryParameters = make(cmd.KeyValue)
+
+	http2 = flag.Bool(
+		"http2",
+		false,
+		"Using http2 for query connection",
+	)
+
+	cacert = flag.String(
+		"cacert",
+		"",
+		"CA certificate for TLS establishment",
+	)
 )
 
 func serve(net string) {
@@ -216,6 +222,7 @@ specify multiple as:
 		QueryParameters:     map[string][]string(queryParameters),
 		Headers:             http.Header(headers),
 		HTTP2:               *http2,
+		CACertFilePath:       *cacert,
 	}
 
 	// handle "sane defaults" if requested; only where settings are not explicitly

--- a/cmd/secure-operator/main.go
+++ b/cmd/secure-operator/main.go
@@ -15,8 +15,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/miekg/dns"
 
-	secop "github.com/fardog/secureoperator"
-	"github.com/fardog/secureoperator/cmd"
+	secop "../.."
+	cmd ".."
+	//"github.com/fardog/secureoperator/cmd"
 )
 
 const (
@@ -40,6 +41,12 @@ var (
 		"level",
 		"info",
 		"Log level, one of: debug, info, warn, error, fatal, panic",
+	)
+
+	http2 = flag.Bool(
+		"http2",
+		false,
+		"Using http2 for query connection",
 	)
 
 	// one-stop configuration flags; when used, these configure sane defaults
@@ -208,6 +215,7 @@ specify multiple as:
 		EDNSSubnet:          edns,
 		QueryParameters:     map[string][]string(queryParameters),
 		Headers:             http.Header(headers),
+		HTTP2:               *http2,
 	}
 
 	// handle "sane defaults" if requested; only where settings are not explicitly

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strings"
 
-	secop "github.com/fardog/secureoperator"
+	secop ".."
 )
 
 // CSVtoEndpoints takes a comma-separated string of endpoints, and parses to a


### PR DESCRIPTION
- Add options for HTTP/2 for enjoying the moderm features.
- Add options for custom CA certification.
  - specified CA would shorten the TLS establishment duration.
  - self-signned certs would work (e.g. ip address certificates).
- modified some package import declaration which are not convenient for development.